### PR TITLE
🔒 Fix XSS vulnerability in ScoreSection rendering

### DIFF
--- a/dev_server.log
+++ b/dev_server.log
@@ -1,0 +1,5 @@
+
+> temp-sv@0.0.1 dev
+> vite dev
+
+sh: 1: vite: not found

--- a/src/lib/components/ScoreSection.svelte
+++ b/src/lib/components/ScoreSection.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { playerState, getOriginalBeats } from '$lib/stores/player.svelte';
+  import { escapeHtml } from '$lib/utils/security';
   
   let viewMode = $state('both');
 
@@ -200,10 +201,10 @@
       // ヘ音記号・拍子記号
       if (row === 0) {
         html += `<text x="12" y="${staffTop + lineSpacing * 2 + 8}" font-size="38" fill="rgba(255,255,255,0.65)" font-family="serif" style="line-height:1">𝄢</text>`;
-        html += `<text x="46" y="${staffTop + lineSpacing * 1.5}" font-size="14" fill="rgba(255,255,255,0.6)" font-family="serif" font-weight="bold">${timeSigNum}</text>`;
-        html += `<text x="46" y="${staffTop + lineSpacing * 3.5}" font-size="14" fill="rgba(255,255,255,0.6)" font-family="serif" font-weight="bold">${timeSigDen}</text>`;
+        html += `<text x="46" y="${staffTop + lineSpacing * 1.5}" font-size="14" fill="rgba(255,255,255,0.6)" font-family="serif" font-weight="bold">${escapeHtml(timeSigNum)}</text>`;
+        html += `<text x="46" y="${staffTop + lineSpacing * 3.5}" font-size="14" fill="rgba(255,255,255,0.6)" font-family="serif" font-weight="bold">${escapeHtml(timeSigDen)}</text>`;
         if (playerState.song.key) {
-          html += `<text x="10" y="${staffTop - 12}" font-size="13" fill="var(--accent)" font-family="'Space Mono',monospace" font-weight="bold">Key: ${playerState.song.key}</text>`;
+          html += `<text x="10" y="${staffTop - 12}" font-size="13" fill="var(--accent)" font-family="'Space Mono',monospace" font-weight="bold">Key: ${escapeHtml(playerState.song.key)}</text>`;
         }
       }
 
@@ -288,7 +289,7 @@
           html += `<circle cx="${x + 9}" cy="${y - 2}" r="1.5" fill="${col}"/>`;
         }
         if (noteState !== 'upcoming')
-          html += `<text x="${x}" y="${rowH - 6}" text-anchor="middle" font-size="8" fill="${col}" font-family="'Space Mono',monospace">${note.name.replace(/\d+$/, '')}</text>`;
+          html += `<text x="${x}" y="${rowH - 6}" text-anchor="middle" font-size="8" fill="${col}" font-family="'Space Mono',monospace">${escapeHtml(note.name.replace(/\d+$/, ''))}</text>`;
         if (noteState === 'current')
           html += `<circle cx="${x}" cy="${y}" r="11" fill="none" stroke="${col}" stroke-width="1.5" opacity="0.4"/>`;
       });
@@ -356,8 +357,8 @@
         const beatNum = (note.beat % timeSigNum) + 1;
         const beatCol = i === playerState.currentNoteIdx ? 'var(--accent)' : 'var(--muted)';
 
-        html += `<div class="tab-note-val ${state}" style="left:${x-8}px;top:${y+1}px;width:16px;">${note.fret}</div>`;
-        html += `<div style="position:absolute;top:104px;left:${x-10}px;width:20px;text-align:center;font-size:8px;color:${beatCol};font-family:'Space Mono',monospace;">${beatNum}</div>`;
+        html += `<div class="tab-note-val ${state}" style="left:${x-8}px;top:${y+1}px;width:16px;">${escapeHtml(note.fret)}</div>`;
+        html += `<div style="position:absolute;top:104px;left:${x-10}px;width:20px;text-align:center;font-size:8px;color:${beatCol};font-family:'Space Mono',monospace;">${escapeHtml(beatNum)}</div>`;
       });
 
       html += `</div>`;

--- a/src/lib/utils/security.ts
+++ b/src/lib/utils/security.ts
@@ -1,0 +1,17 @@
+/**
+ * Escapes HTML special characters in a string to prevent XSS.
+ * @param input The input to escape (will be coerced to string).
+ * @returns The escaped string.
+ */
+export function escapeHtml(input: any): string {
+  const str = String(input);
+  return str.replace(/[&<>"']/g, (m) => {
+    return {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#39;',
+    }[m] as string;
+  });
+}


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
XSS in `ScoreSection.svelte` where unsanitized `Song` properties (key, note names, etc.) from user-controlled iReal Pro URIs were rendered using `innerHTML`.

⚠️ **Risk:** The potential impact if left unfixed
Malicious actors could craft iReal Pro URIs containing scripts that execute in the user's browser when imported, potentially stealing session data or performing actions on behalf of the user.

🛡️ **Solution:** How the fix addresses the vulnerability
- Implemented a robust `escapeHtml` utility in `src/lib/utils/security.ts`.
- Applied `escapeHtml` to all user-controllable strings and numeric values before they are concatenated into the HTML string used for `scoreContainer.innerHTML`.
- Ensured all dynamic parts of the score (Key, note names, fret numbers, time signatures, beat numbers) are properly sanitized.

---
*PR created automatically by Jules for task [10871413406023044789](https://jules.google.com/task/10871413406023044789) started by @edgeless*