### PR TITLE
進捗バーの動きを連続的にする #12

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,3 +193,6 @@ npm run test       # 両方を実行
 docker compose -f compose.test.yaml run unit
 docker compose -f compose.test.yaml run e2etest
 ```
+
+## アニメーションの更新
+UIアニメーション（特に進捗バーなど）を更新する際は、requestAnimationFrameを用いて連続的かつ滑らかに描画するアプローチを検討してください。

--- a/README.md
+++ b/README.md
@@ -205,3 +205,6 @@ docker compose -f compose.test.yaml run unit
 docker compose -f compose.test.yaml run e2etest
 ```
 ```
+
+## 進捗バーの連続アニメーション
+進捗バーのアニメーションは、requestAnimationFrame を用いてピクセル単位で滑らかに更新されるように改善されました。

--- a/src/lib/components/Transport.svelte
+++ b/src/lib/components/Transport.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { playerState, getTotalBeats, getOriginalBeats, getTotalDurationSeconds } from '$lib/stores/player.svelte';
-  import { onMount } from 'svelte';
   import { scoreState, resetScore } from '$lib/stores/score.svelte';
   import { audioState, playClick } from '$lib/stores/audio.svelte';
   import { midiToFreq, freqToCents, freqToMidi, getGrade, getTimingGrade, getCombinedGrade } from '$lib/utils/pitch';
@@ -46,6 +45,7 @@
         cancelAnimationFrame(animationFrameId);
       };
     } else {
+      if (animationFrameId) cancelAnimationFrame(animationFrameId);
       displayBeat = playerState.currentBeat;
     }
   });
@@ -285,6 +285,10 @@
     playerState.status = 'play';
 
     // Set playbackStartTimeMs based on currentBeat
+    // Note: In startPlay, this value represents the theoretical start time of the song
+    // calculated backwards from the current position. This is primarily used to drive
+    // the continuous displayBeat animation. This differs slightly from startRecord
+    // where it strictly anchors the expected timing for grading.
     const secPerBeat = 60 / playerState.song.bpm;
     if (playerState.isFreeMode) {
       playerState.playbackStartTimeMs = performance.now() - (playerState.currentBeat * secPerBeat * 1000);

--- a/src/lib/components/Transport.svelte
+++ b/src/lib/components/Transport.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { playerState, getTotalBeats, getOriginalBeats, getTotalDurationSeconds } from '$lib/stores/player.svelte';
+  import { onMount } from 'svelte';
   import { scoreState, resetScore } from '$lib/stores/score.svelte';
   import { audioState, playClick } from '$lib/stores/audio.svelte';
   import { midiToFreq, freqToCents, freqToMidi, getGrade, getTimingGrade, getCombinedGrade } from '$lib/utils/pitch';
@@ -14,14 +15,49 @@
     return `${isNeg ? '-' : ''}${m}:${s.toString().padStart(2, '0')}`;
   }
 
+
+  // Display beat for continuous progress
+  let displayBeat = $state(0);
+  let animationFrameId: number;
+
+  $effect(() => {
+    if (playerState.isPlaying || playerState.isRecording) {
+      function updateDisplay() {
+        if (playerState.playbackStartTimeMs !== null) {
+          const now = performance.now();
+          const elapsedMs = now - playerState.playbackStartTimeMs;
+          const secPerBeat = 60 / playerState.song.bpm;
+          let newDisplayBeat;
+          if (playerState.isFreeMode) {
+             newDisplayBeat = elapsedMs / (secPerBeat * 1000);
+          } else {
+             newDisplayBeat = (elapsedMs / (secPerBeat * 1000)) - 4; // offset by 4 for count-in
+          }
+
+          displayBeat = newDisplayBeat;
+        } else {
+          displayBeat = playerState.currentBeat;
+        }
+        animationFrameId = requestAnimationFrame(updateDisplay);
+      }
+      animationFrameId = requestAnimationFrame(updateDisplay);
+
+      return () => {
+        cancelAnimationFrame(animationFrameId);
+      };
+    } else {
+      displayBeat = playerState.currentBeat;
+    }
+  });
+
   // Derived progress values
   let progressPct = $derived(
-    getTotalBeats() ? (playerState.currentBeat / getTotalBeats()) * 100 : 0
+    getTotalBeats() ? (displayBeat / getTotalBeats()) * 100 : 0
   );
   let posSec = $derived(
     playerState.isFreeMode
-      ? (playerState.currentBeat < 0 ? 0 : (playerState.currentBeat / playerState.song.bpm) * 60) // フリーモード時も song.bpm に合わせる (tick と整合性を取る)
-      : (playerState.currentBeat / playerState.song.bpm) * 60
+      ? (displayBeat < 0 ? 0 : (displayBeat / playerState.song.bpm) * 60) // フリーモード時も song.bpm に合わせる (tick と整合性を取る)
+      : (displayBeat / playerState.song.bpm) * 60
   );
 
   function scheduleBeat() {
@@ -86,7 +122,22 @@
       }
 
       playerState.currentBeat++;
-      beatInterval = setTimeout(tick, secPerBeat * 1000);
+
+      // Calculate absolute time for next beat to prevent timing drift
+      if (playerState.playbackStartTimeMs !== null) {
+        let expectedNextBeatTimeMs;
+        if (playerState.isFreeMode) {
+          expectedNextBeatTimeMs = playerState.playbackStartTimeMs + (playerState.currentBeat * secPerBeat * 1000);
+        } else {
+          expectedNextBeatTimeMs = playerState.playbackStartTimeMs + ((playerState.currentBeat + 4) * secPerBeat * 1000);
+        }
+
+        const now = performance.now();
+        const delayMs = Math.max(0, expectedNextBeatTimeMs - now);
+        beatInterval = setTimeout(tick, delayMs);
+      } else {
+        beatInterval = setTimeout(tick, secPerBeat * 1000);
+      }
     }
     tick();
   }
@@ -232,6 +283,15 @@
     if (!audioState.audioCtx) return;
     playerState.isPlaying = true;
     playerState.status = 'play';
+
+    // Set playbackStartTimeMs based on currentBeat
+    const secPerBeat = 60 / playerState.song.bpm;
+    if (playerState.isFreeMode) {
+      playerState.playbackStartTimeMs = performance.now() - (playerState.currentBeat * secPerBeat * 1000);
+    } else {
+      playerState.playbackStartTimeMs = performance.now() - ((playerState.currentBeat + 4) * secPerBeat * 1000);
+    }
+
     scheduleBeat();
   }
 
@@ -322,6 +382,16 @@
     const targetBeat = Math.floor(pct * totalBeats);
     playerState.currentBeat = targetBeat;
 
+    // Update playbackStartTimeMs if we are playing or recording
+    if (playerState.isPlaying || playerState.isRecording) {
+      const secPerBeat = 60 / playerState.song.bpm;
+      if (playerState.isFreeMode) {
+        playerState.playbackStartTimeMs = performance.now() - (targetBeat * secPerBeat * 1000);
+      } else {
+        playerState.playbackStartTimeMs = performance.now() - ((targetBeat + 4) * secPerBeat * 1000);
+      }
+    }
+
     // リピート時のループ番号とループ内ビート位置を計算
     if (originalBeats > 0) {
       playerState.currentLoop = Math.floor(targetBeat / originalBeats) + 1;
@@ -410,7 +480,7 @@
 #progFill {
   height: 100%; border-radius: 2px;
   background: linear-gradient(90deg, var(--accent2), var(--accent));
-  position: relative; transition: width 0.1s linear;
+  position: relative;
 }
 #progFill::after { content:''; position:absolute; right:-5px; top:-3px; width:10px; height:10px; border-radius:50%; background:var(--accent); box-shadow:0 0 6px var(--accent); }
 

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -16,3 +16,23 @@ test('loads the app and shows main layout elements', async ({ page }) => {
   // Check if the transport component is visible (it's a div, not a footer)
   await expect(page.locator('div.transport').first()).toBeVisible();
 });
+
+
+test('transport components are correctly rendered and accessible', async ({ page }) => {
+  await page.goto('/');
+
+  // dismiss overlay
+  const dismissBtn = page.locator("button:has-text('マイク')");
+  if (await dismissBtn.isVisible()) {
+    await dismissBtn.click();
+  }
+
+  // Check the initial state of the progress bar track
+  const progFill = page.locator('#progFill');
+  await expect(progFill).toBeAttached();
+
+  // ensure the transport buttons are present
+  await expect(page.locator(".tbtn:has-text('▶')")).toBeVisible();
+  await expect(page.locator(".tbtn:has-text('⏺')")).toBeVisible();
+  await expect(page.locator(".tbtn[title='停止']")).toBeVisible();
+});


### PR DESCRIPTION
進捗バーが1ビートごとではなく、ピクセル単位で滑らかに動くように実装を修正しました。

## 対応内容
- `requestAnimationFrame` による連続的なプログレス更新処理を `Transport.svelte` に追加
- `progressPct` とタイムスタンプの更新を `displayBeat` (実時間の計算結果) に依存するように変更
- カクつきや再計算のラグを防ぐため、CSSの `transition: width 0.1s linear;` を削除
- `scheduleBeat` (tick) 内での setTimeout の指定を、`playbackStartTimeMs` と現在時刻 `performance.now()` から算出した絶対時間ベースに変更（タイミングのドリフト防止）
- E2Eテスト (`tests/e2e/home.spec.ts`) の更新
- ルールに従い `README.md` と `AGENTS.md` の更新を実施

ご確認よろしくお願いいたします。

---
*PR created automatically by Jules for task [4465509408200956918](https://jules.google.com/task/4465509408200956918) started by @edgeless*