### PR TITLE
🔒 [security fix] Add Content Security Policy (CSP)

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -4,7 +4,7 @@
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>FRETLESS — Bass Practice Studio</title>
-		<link href="https://fonts.googleapis.com/css2?family=Space+Mono:ital,wght@0,400;0,700;1,400&family=Noto+Sans+JP:wght@300;400;700&family=Bebas+Neue&display=swap" rel="stylesheet">
+		<link href="https://fonts.googleapis.com/css2?family=Space+Mono:ital,wght@0,400;0,700;1,400&family=Noto+Sans+JP:wght@300;400;700&family=Bebas+Neue&display=swap" rel="stylesheet" nonce="%sveltekit.nonce%">
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -16,7 +16,21 @@ const config = {
 	kit: {
 		// adapter-node is used for containerized deployment (Cloud Run, etc.)
 		// See https://svelte.dev/docs/kit/adapter-node for more information.
-		adapter: adapter()
+		adapter: adapter(),
+		csp: {
+			mode: 'auto',
+			directives: {
+				'default-src': ['self'],
+				'script-src': ['self'],
+				'style-src': ['self', 'unsafe-inline', 'https://fonts.googleapis.com'],
+				'font-src': ['self', 'https://fonts.gstatic.com'],
+				'img-src': ['self', 'data:'],
+				'media-src': ['self', 'blob:'],
+				'connect-src': ['self'],
+				'object-src': ['none'],
+				'base-uri': ['self']
+			}
+		}
 	}
 };
 


### PR DESCRIPTION
🎯 **概要 (What)**
SvelteKitの設定にコンテンツセキュリティポリシー (CSP) を追加しました。

⚠️ **リスク (Risk)**
CSPが未設定の場合、クロスサイトスクリプティング (XSS) や不正な外部リソースの読み込みに対して脆弱であり、ユーザーデータの安全性が脅かされる可能性があります。

🛡️ **解決策 (Solution)**
`svelte.config.js` に `kit.csp` を設定し、`src/app.html` のGoogle Fontsリンクにノンスを追加しました。
`mode: 'auto'` を使用することで、SvelteKitが生成するスクリプトやスタイルに対して自動的にハッシュやノンスが付与され、安全性が向上します。
また、Google Fonts (`fonts.googleapis.com`, `fonts.gstatic.com`) や録音データの再生に必要な `blob:` などの正当なリソースのみを許可するようにディレクティブを定義しています。

主なディレクティブ設定:
- `default-src 'self'`: デフォルトで自オリジンのみを許可。
- `script-src 'self'`: 自オリジンのスクリプトを許可（SvelteKitによりハッシュ/ノンスが適用されます）。
- `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com`: 自オリジン、インラインスタイル（Svelteの機能に必要）、およびGoogle FontsのCSSを許可。
- `font-src 'self' https://fonts.gstatic.com`: Google Fontsのフォントファイルを許可。
- `img-src 'self' data:`: ファビコンなどのデータURIを許可。
- `media-src 'self' blob:`: 録音データの再生に必要なBlob URLを許可。
- `connect-src 'self'`: 自オリジンへの通信を許可。
- `object-src 'none'`: プラグインの読み込みを禁止。
- `base-uri 'self'`: `<base>` タグの遷移先を制限。

---
*PR created automatically by Jules for task [5769358815074404735](https://jules.google.com/task/5769358815074404735) started by @edgeless*