### PR TITLE
feat: 選曲や設定をlocalStorageに保存する機能の追加

### DIFF
--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -78,6 +78,14 @@
       transportRef.toggleDemoPlay();
     }
   }
+
+  $effect(() => {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem('player_song_key', playerState.currentSongKey);
+      localStorage.setItem('player_bpm', playerState.song.bpm.toString());
+      localStorage.setItem('player_repeat', playerState.repeatCount.toString());
+    }
+  });
 </script>
 
 <header>

--- a/src/lib/components/Transport.svelte
+++ b/src/lib/components/Transport.svelte
@@ -704,6 +704,12 @@
       playerState.currentNoteIdx = targetNoteIdx;
     }
   }
+
+  $effect(() => {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem('player_tolerance', playerState.tolerance.toString());
+    }
+  });
 </script>
 
 <div class="transport">

--- a/src/lib/stores/player.svelte.ts
+++ b/src/lib/stores/player.svelte.ts
@@ -21,6 +21,11 @@ interface PlayerState {
 
 // 初期化時に localStorage からインポート曲を読み込む
 let initialImported: Song | null = null;
+let initialSongKey = 'c_major';
+let initialBpm: number | null = null;
+let initialRepeatCount = 1;
+let initialTolerance = 20;
+
 if (browser) {
   const saved = localStorage.getItem('imported_song');
   if (saved) {
@@ -30,25 +35,63 @@ if (browser) {
       console.error("Failed to load imported song", e);
     }
   }
+
+  const savedKey = localStorage.getItem('player_song_key');
+  if (savedKey) {
+    if (savedKey === 'imported' && initialImported) {
+      initialSongKey = 'imported';
+    } else if (SONGS[savedKey]) {
+      initialSongKey = savedKey;
+    }
+  } else if (initialImported) {
+    initialSongKey = 'imported';
+  }
+
+  const savedBpm = localStorage.getItem('player_bpm');
+  if (savedBpm) {
+    const bpm = parseInt(savedBpm, 10);
+    if (!isNaN(bpm) && bpm >= 10 && bpm <= 300) {
+      initialBpm = bpm;
+    }
+  }
+
+  const savedRepeat = localStorage.getItem('player_repeat');
+  if (savedRepeat) {
+    const repeat = parseInt(savedRepeat, 10);
+    if (!isNaN(repeat) && repeat >= 1 && repeat <= 99) {
+      initialRepeatCount = repeat;
+    }
+  }
+
+  const savedTolerance = localStorage.getItem('player_tolerance');
+  if (savedTolerance) {
+    const tol = parseInt(savedTolerance, 10);
+    if (!isNaN(tol) && tol >= 5 && tol <= 50) {
+      initialTolerance = tol;
+    }
+  }
 }
 
 function calculateCountIn(song: Song) {
   return song.timeSignature?.[0] ?? 4;
 }
 
-const initialSong = (initialImported || SONGS['c_major']) as Song;
+const initialSong = (initialSongKey === 'imported' && initialImported ? initialImported : SONGS[initialSongKey]) as Song;
+if (initialBpm) {
+  initialSong.bpm = initialBpm;
+}
 
 export const playerState = $state<PlayerState>({
-  currentSongKey: initialImported ? 'imported' : 'c_major',
+  currentSongKey: initialSongKey,
   song: initialSong,
   currentNoteIdx: 0,
   currentBeat: -calculateCountIn(initialSong),
   isPlaying: false,
   isRecording: false,
-  tolerance: 20, // cents
+  tolerance: initialTolerance, // cents
   metronomeOn: false,
   status: 'idle',
-  repeatCount: 1,
+  repeatCount: initialRepeatCount,
   currentLoop: 1,
   importedSong: initialImported,
   isFreeMode: false,


### PR DESCRIPTION
Issue #45 に対応し、選択中の曲（BPM、リピート回数、許容誤差含む）を `localStorage` に保存して、次回アクセス時に復元する機能を実装しました。

- `src/lib/stores/player.svelte.ts`: 初期化時に `localStorage` から `player_song_key`, `player_bpm`, `player_repeat`, `player_tolerance` を読み込み、初期ステートに反映するように改修しました。
- `src/lib/components/Header.svelte`: 曲、BPM、リピート回数が変更された際に自動的に `localStorage` へ保存する `$effect` ブロックを追加しました。
- `src/lib/components/Transport.svelte`: 許容誤差（Tolerance）が変更された際に自動的に `localStorage` へ保存する `$effect` ブロックを追加しました。

これにより、ページをリロードしてもユーザーの直近の練習設定が保持されるようになります。

---
*PR created automatically by Jules for task [14428379779010494767](https://jules.google.com/task/14428379779010494767) started by @edgeless*