### PR TITLE
🧪 [testing improvement] player storeのビート・再生時間計算ロジックのテスト追加

### DIFF
--- a/tests/unit/player.test.ts
+++ b/tests/unit/player.test.ts
@@ -1,6 +1,12 @@
 import { describe, test, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
-import { playerState, getDisplayBeat } from '../../src/lib/stores/player.svelte';
+import {
+  playerState,
+  getDisplayBeat,
+  getOriginalBeats,
+  getTotalBeats,
+  getTotalDurationSeconds
+} from '../../src/lib/stores/player.svelte';
 
 describe('getDisplayBeat', () => {
   let originalPerformanceNow: typeof performance.now;
@@ -81,5 +87,50 @@ describe('getDisplayBeat', () => {
 
     const displayBeat = getDisplayBeat();
     assert.strictEqual(displayBeat, 5);
+  });
+});
+
+describe('Beat and Duration Calculations', () => {
+  beforeEach(() => {
+    playerState.repeatCount = 1;
+    playerState.song = {
+      name: 'Test',
+      bpm: 60,
+      notes: []
+    };
+  });
+
+  test('getOriginalBeats returns 0 when notes array is empty', () => {
+    playerState.song.notes = [];
+    assert.strictEqual(getOriginalBeats(), 0);
+  });
+
+  test('getOriginalBeats returns sum of beat and dur of the last note', () => {
+    playerState.song.notes = [
+      { name: 'C2', midi: 36, string: 'A', fret: 3, beat: 0, dur: 4 },
+      { name: 'G2', midi: 43, string: 'E', fret: 3, beat: 4, dur: 4 }
+    ];
+    // Last note: beat=4, dur=4 -> 4+4=8
+    assert.strictEqual(getOriginalBeats(), 8);
+  });
+
+  test('getTotalBeats correctly multiplies getOriginalBeats by repeatCount', () => {
+    playerState.song.notes = [
+      { name: 'C2', midi: 36, string: 'A', fret: 3, beat: 0, dur: 4 }
+    ];
+    // Original beats = 4
+    playerState.repeatCount = 3;
+    assert.strictEqual(getTotalBeats(), 12);
+  });
+
+  test('getTotalDurationSeconds correctly calculates duration based on totalBeats and bpm', () => {
+    playerState.song.notes = [
+      { name: 'C2', midi: 36, string: 'A', fret: 3, beat: 0, dur: 4 }
+    ];
+    playerState.song.bpm = 120;
+    playerState.repeatCount = 1;
+    // Original beats = 4. Total beats = 4.
+    // Duration = (4 / 120) * 60 = 2 seconds.
+    assert.strictEqual(getTotalDurationSeconds(), 2);
   });
 });


### PR DESCRIPTION
### 🎯 What
`src/lib/stores/player.svelte.ts` 内の以下の関数に対するユニットテストを追加しました。
- `getOriginalBeats`
- `getTotalBeats`
- `getTotalDurationSeconds`

### 📊 Coverage
以下のシナリオをテスト対象に加えました：
- **getOriginalBeats**: 
  - 音符データがない場合に 0 を返すこと
  - 最後の音符の `beat` と `dur` の合計値を正しく返すこと
- **getTotalBeats**: 
  - `repeatCount` に基づいて総ビート数が正しく計算されること
- **getTotalDurationSeconds**: 
  - BPM と総ビート数から、再生時間が秒単位で正しく算出されること

### ✨ Result
player store における主要な時間計算ロジックのテストカバレッジが向上しました。
また、意図的にロジックを壊した際にテストが失敗することも確認済みです。

---
*PR created automatically by Jules for task [14450564938016689847](https://jules.google.com/task/14450564938016689847) started by @edgeless*