### PR TITLE
🔒 [security] ScoreSection における XSS 脆弱性の修正

### DIFF
--- a/src/lib/components/ScoreSection.svelte
+++ b/src/lib/components/ScoreSection.svelte
@@ -251,12 +251,12 @@
       });
 
       // 小節番号・小節線
-      html += `<text x="${layout.startX}" y="${staffTop - 4}" font-size="7" fill="rgba(255,255,255,0.25)" font-family="'Space Mono',monospace">${layout.rowStartMeasure + 1}</text>`;
+      html += `<text x="${layout.startX}" y="${staffTop - 4}" font-size="7" fill="rgba(255,255,255,0.25)" font-family="'Space Mono',monospace">${escapeHtml(layout.rowStartMeasure + 1)}</text>`;
       layout.elements.forEach((el, j) => {
         if (el.type === 'bar') {
           const bx = layout.elPositions[j];
           html += `<line x1="${bx}" y1="${staffTop}" x2="${bx}" y2="${staffTop + staffH}" stroke="rgba(255,255,255,0.3)" stroke-width="1"/>`;
-          html += `<text x="${bx + 3}" y="${staffTop - 4}" font-size="7" fill="rgba(255,255,255,0.25)" font-family="'Space Mono',monospace">${el.measureNum}</text>`;
+          html += `<text x="${bx + 3}" y="${staffTop - 4}" font-size="7" fill="rgba(255,255,255,0.25)" font-family="'Space Mono',monospace">${escapeHtml(el.measureNum)}</text>`;
         }
       });
 
@@ -402,10 +402,10 @@
         if (el.type === 'bar') {
           const bx = layout.elPositions[j];
           html += `<div class="tab-bar-line" style="left:${bx}px;height:78px;top:20px;"></div>`;
-          html += `<span style="position:absolute;top:5px;left:${bx+3}px;font-size:7px;color:rgba(255,255,255,0.25);">${el.measureNum}</span>`;
+          html += `<span style="position:absolute;top:5px;left:${bx+3}px;font-size:7px;color:rgba(255,255,255,0.25);">${escapeHtml(el.measureNum)}</span>`;
         }
       });
-      html += `<span style="position:absolute;top:5px;left:${layout.startX}px;font-size:7px;color:rgba(255,255,255,0.25);">${layout.rowStartMeasure+1}</span>`;
+      html += `<span style="position:absolute;top:5px;left:${layout.startX}px;font-size:7px;color:rgba(255,255,255,0.25);">${escapeHtml(layout.rowStartMeasure+1)}</span>`;
 
       // ノート
       notes.forEach((note, i) => {


### PR DESCRIPTION
🎯 **内容:** `ScoreSection.svelte` において、小節番号などの動的データがサニタイズされずに `innerHTML` 経由で描画されていた箇所を修正しました。なお、指摘のあった `note.name` についてはベースコミット時点で既に `escapeHtml` が適用されていることを確認しました。

⚠️ **リスク:** 不適切に構成された楽曲データが読み込まれた際、小節番号などのフィールドを介して DOM XSS が発生する可能性があります。

🛡️ **解決策:** `escapeHtml` ユーティリティを使用して、小節番号（`layout.rowStartMeasure + 1` および `el.measureNum`）を挿入前にサニタイズするように変更し、安全性を高めました。

---
*PR created automatically by Jules for task [12969610837281038625](https://jules.google.com/task/12969610837281038625) started by @edgeless*