### PR TITLE
削除済みの関数に関するユニットテストを修正

### DIFF
--- a/tests/unit/pitch.test.ts
+++ b/tests/unit/pitch.test.ts
@@ -8,7 +8,6 @@ import {
   getGrade,
   getTimingGrade,
   getCombinedGrade,
-  detectPitchHQ,
   detectPitch
 } from '../../src/lib/utils/pitch';
 
@@ -82,18 +81,6 @@ describe('pitch utils', () => {
     assert.strictEqual(getCombinedGrade('good', 'ok'), 'ok'); // (2+1)/2 = 1.5 -> 1 (ok)
     assert.strictEqual(getCombinedGrade('miss', 'perfect'), 'ok'); // (0+3)/2 = 1.5 -> 1 (ok)
     assert.strictEqual(getCombinedGrade('miss', 'miss'), 'miss');
-  });
-
-  test('detectPitchHQ detects pitch from samples', () => {
-    const sr = 44100;
-    const freq = 110; // A2
-    const samples = new Array(2048);
-    for (let i = 0; i < samples.length; i++) {
-      samples[i] = Math.sin(2 * Math.PI * freq * i / sr);
-    }
-
-    const detected = detectPitchHQ(samples, sr);
-    assert.ok(Math.abs(detected - freq) < 1);
   });
 
   test('detectPitch detects pitch with mocked AnalyserNode', () => {


### PR DESCRIPTION
PR #61で指摘されたCIテストの失敗を修正しました。

`src/lib/utils/pitch.ts` から `detectPitchHQ` 関数が既に削除されていましたが、ユニットテスト (`tests/unit/pitch.test.ts`) に該当するテストとインポートが残っていたため、SyntaxErrorが発生していました。このコミットでは、不要になったテストケースを削除することでエラーを解決しました。ユニットテストおよびE2Eテストが正常に通過することを確認済みです。

---
*PR created automatically by Jules for task [15529717560687085843](https://jules.google.com/task/15529717560687085843) started by @edgeless*