### PR TITLE
fix: add descriptive error for insecure context in microphone access

### DIFF
--- a/src/lib/stores/audio.svelte.ts
+++ b/src/lib/stores/audio.svelte.ts
@@ -102,6 +102,10 @@ export async function requestMic(deviceIdOrEvent?: string | Event) {
     };
     let stream: MediaStream;
 
+    if (!navigator.mediaDevices) {
+      throw new Error("ブラウザのセキュリティ制限によりマイクにアクセスできません。HTTPS接続または localhost でアクセスしているか確認してください。");
+    }
+
     try {
       stream = await navigator.mediaDevices.getUserMedia(constraints);
     } catch (e) {


### PR DESCRIPTION
## 概要
非セキュアなコンテキスト（HTTPアクセスなど）でマイクアクセスを試みた際に、ブラウザが `navigator.mediaDevices` を提供しないため `TypeError` が発生していた問題を修正しました。

## 変更内容
- `src/lib/stores/audio.svelte.ts` にて、`getUserMedia` を呼び出す前に `navigator.mediaDevices` の存在チェックを追加。
- 存在しない場合は、ユーザーにHTTPSまたはlocalhostでのアクセスが必要であることを伝える日本語のエラーメッセージをスローするように変更。

## 確認事項
- [x] 非セキュアなコンテキスト（IPアドレスでのHTTPアクセス）で、分かりやすいエラーメッセージが表示されること。
- [x] `chrome://flags/#unsafely-treat-insecure-origin-as-secure` 等で許可した場合は正常に動作すること。