### PR TITLE
feat: ドローン音再生機能の追加

### DIFF
--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   import { playerState, setSong } from '$lib/stores/player.svelte';
-  import { audioState, requestMic, setOutputDevice } from '$lib/stores/audio.svelte';
+  import { audioState, requestMic, setOutputDevice, startDrone, stopDrone } from '$lib/stores/audio.svelte';
   import { SONGS } from '$lib/utils/songs';
   import { parseIRealURI } from '$lib/utils/ireal';
+  import { keyToDroneFreq } from '$lib/utils/pitch';
   import type Transport from './Transport.svelte';
 
   let { transportRef } = $props<{ transportRef: ReturnType<typeof Transport> | undefined }>();
@@ -14,6 +15,19 @@
 
   function toggleMetronome() {
     playerState.metronomeOn = !playerState.metronomeOn;
+  }
+
+  function toggleDrone() {
+    playerState.droneOn = !playerState.droneOn;
+    // 再生・録音中にドローンが切り替えられた場合は即座に反映する
+    if (playerState.isPlaying || playerState.isRecording) {
+      if (playerState.droneOn && playerState.song.key) {
+        const freq = keyToDroneFreq(playerState.song.key);
+        if (freq) startDrone(freq);
+      } else {
+        stopDrone();
+      }
+    }
   }
 
   function onInputDeviceChange(e: Event) {
@@ -62,6 +76,7 @@
       importError: isJa ? "URLの解析に失敗しました。正しいURLか確認してください。" : "Failed to parse the URL. Please make sure it's a valid iReal Pro URL.",
       scrollHint: isJa ? "スクロールで変更" : "Scroll to change",
       clickBtn: isJa ? "♩ メトロノーム" : "♩ CLICK",
+      droneBtn: isJa ? "🎶 ドローン音" : "🎶 DRONE",
       inputDev: isJa ? "入力デバイス" : "Input Device",
       outputDev: isJa ? "出力デバイス" : "Output Device",
       repeat: isJa ? "リピート" : "Repeat",
@@ -138,6 +153,12 @@
       disabled={playerState.status !== 'idle'}
     >
       {i18n.freeMode}
+    </button>
+    <button
+      class="btn-sm {playerState.droneOn ? 'active' : ''}"
+      onclick={toggleDrone}
+    >
+      {i18n.droneBtn}
     </button>
     <button 
       class="btn-sm {playerState.metronomeOn ? 'active' : ''}" 

--- a/src/lib/components/Transport.svelte
+++ b/src/lib/components/Transport.svelte
@@ -2,8 +2,8 @@
   import { onDestroy } from 'svelte';
   import { playerState, getTotalBeats, getOriginalBeats, getTotalDurationSeconds, getDisplayBeat, getCountInBeats } from '$lib/stores/player.svelte';
   import { scoreState, resetScore } from '$lib/stores/score.svelte';
-  import { audioState, playClick, playDemoNote, stopDemoNotes, setMasterVolume } from '$lib/stores/audio.svelte';
-  import { midiToFreq, freqToCents, freqToMidi, getGrade, getTimingGrade, getCombinedGrade } from '$lib/utils/pitch';
+  import { audioState, playClick, playDemoNote, stopDemoNotes, setMasterVolume, startDrone, stopDrone } from '$lib/stores/audio.svelte';
+  import { midiToFreq, freqToCents, freqToMidi, getGrade, getTimingGrade, getCombinedGrade, keyToDroneFreq } from '$lib/utils/pitch';
 
   let beatInterval: any = null;
 
@@ -478,6 +478,11 @@
     playerState.isPlaying = true;
     playerState.status = 'play';
 
+    if (playerState.droneOn && playerState.song.key) {
+      const freq = keyToDroneFreq(playerState.song.key);
+      if (freq) startDrone(freq);
+    }
+
     // Set playbackStartTimeMs based on currentBeat
     // Note: In startPlay, this value represents the theoretical start time of the song
     // calculated backwards from the current position. This is primarily used to drive
@@ -535,6 +540,7 @@
     if (beatInterval) clearTimeout(beatInterval);
     playerState.status = 'idle';
     stopDemoNotes();
+    stopDrone();
     if (playbackAudio) {
       playbackAudio.pause();
     }
@@ -546,6 +552,7 @@
     playerState.isDemoPlaying = false;
     if (beatInterval) clearTimeout(beatInterval);
     stopDemoNotes();
+    stopDrone();
     playerState.currentNoteIdx = 0;
     const countIn = getCountInBeats();
     playerState.currentBeat = -countIn;
@@ -615,6 +622,11 @@
     resetScore();
     playerState.status = 'rec';
 
+    if (playerState.droneOn && playerState.song.key) {
+      const freq = keyToDroneFreq(playerState.song.key);
+      if (freq) startDrone(freq);
+    }
+
     // 音声の録音設定
     if (audioState.micSource) {
       // 以前の録音URLがあれば破棄
@@ -681,6 +693,7 @@
     if (waitPromise) {
       await waitPromise;
     }
+    stopDrone();
 
     if (playerState.isFreeMode) {
       finalizeFreeModeSession();

--- a/src/lib/stores/audio.svelte.ts
+++ b/src/lib/stores/audio.svelte.ts
@@ -237,6 +237,55 @@ export function playClick(accent: boolean) {
 }
 
 // 進行中のデモ用オシレーターを管理するリスト
+let activeDroneOscillator: OscillatorNode | null = null;
+let activeDroneGain: GainNode | null = null;
+
+export function startDrone(freq: number) {
+  const ac = audioState.audioCtx;
+  if (!ac) return;
+
+  stopDrone(); // 既存のドローン音があれば停止
+
+  const osc = ac.createOscillator();
+  const gain = ac.createGain();
+
+  osc.type = 'sine'; // サイン波
+  osc.frequency.value = freq;
+
+  osc.connect(gain);
+  gain.connect(ac.destination);
+
+  // 少しずつフェードインして柔らかく鳴らす
+  const time = ac.currentTime;
+  const maxGain = 0.2 * audioState.masterVolume;
+
+  gain.gain.setValueAtTime(0, time);
+  gain.gain.linearRampToValueAtTime(maxGain, time + 0.5);
+
+  osc.start(time);
+
+  activeDroneOscillator = osc;
+  activeDroneGain = gain;
+}
+
+export function stopDrone() {
+  if (activeDroneOscillator && activeDroneGain) {
+    const ac = audioState.audioCtx;
+    if (ac) {
+      const time = ac.currentTime;
+      // フェードアウト
+      activeDroneGain.gain.cancelScheduledValues(time);
+      activeDroneGain.gain.setValueAtTime(activeDroneGain.gain.value, time);
+      activeDroneGain.gain.linearRampToValueAtTime(0.001, time + 0.3);
+      activeDroneOscillator.stop(time + 0.35);
+    } else {
+      activeDroneOscillator.stop();
+    }
+    activeDroneOscillator = null;
+    activeDroneGain = null;
+  }
+}
+
 export const activeDemoOscillators: OscillatorNode[] = [];
 
 export function stopDemoNotes() {

--- a/src/lib/stores/player.svelte.ts
+++ b/src/lib/stores/player.svelte.ts
@@ -10,6 +10,7 @@ interface PlayerState {
   isRecording: boolean;
   tolerance: number;
   metronomeOn: boolean;
+  droneOn: boolean;
   status: 'idle' | 'play' | 'rec';
   repeatCount: number;
   currentLoop: number;
@@ -90,6 +91,7 @@ export const playerState = $state<PlayerState>({
   isRecording: false,
   tolerance: initialTolerance, // cents
   metronomeOn: false,
+  droneOn: false,
   status: 'idle',
   repeatCount: initialRepeatCount,
   currentLoop: 1,

--- a/src/lib/utils/pitch.ts
+++ b/src/lib/utils/pitch.ts
@@ -98,6 +98,36 @@ export function freqToMidi(freq: number): number {
   return Math.round(69 + 12 * Math.log2(freq / 440));
 }
 
+export function keyToDroneFreq(key: string | undefined): number | null {
+  if (!key) return null;
+
+  // キー文字列からルート音を抽出（例: "C-7" -> "C", "Eb" -> "Eb", "F#" -> "F#"）
+  const match = key.match(/^[A-G][#b]?/);
+  if (!match) return null;
+  const rootNote = match[0];
+
+  // C1 (MIDI 24) をベースとする（ドローン音は低めに設定）
+  const noteOffsets: Record<string, number> = {
+    'C': 0, 'C#': 1, 'Db': 1,
+    'D': 2, 'D#': 3, 'Eb': 3,
+    'E': 4,
+    'F': 5, 'F#': 6, 'Gb': 6,
+    'G': 7, 'G#': 8, 'Ab': 8,
+    'A': 9, 'A#': 10, 'Bb': 10,
+    'B': 11
+  };
+
+  const offset = noteOffsets[rootNote];
+  if (offset === undefined) return null;
+
+  // C2 (MIDI 36) ～ B2 (MIDI 47) をドローン音の基準オクターブとする
+  // (C1の32Hz付近はスマホ等のスピーカーで聞こえづらいため)
+  const baseMidi = 36;
+  const droneMidi = baseMidi + offset;
+
+  return midiToFreq(droneMidi);
+}
+
 export function midiToNoteName(midi: number): string {
   if (midi < 0) return '—';
   const notes = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];


### PR DESCRIPTION
issue #34 「ドローン音再生機能の追加」に対応しました。

**変更内容:**
- **UI:** ヘッダーのメトロノームボタンの左に「🎶 ドローン音」ボタンを追加しました。
- **音声処理:** 曲のキー（調）を判定し、そのルート音に基づく持続音（ドローン音）をサイン波で生成するロジックを実装しました。音程は、スマートフォンやPCのスピーカーでも比較的聞こえやすい低音域（C2〜B2）に設定しています。
- **連携機能:** 再生ボタン（デモ再生を含む）または録音ボタンを押した際に、ドローン音モードがオンになっていれば、曲のキーに合わせてドローン音がフェードインしながら鳴り始めます。停止するとフェードアウトして止まります。再生中や録音中にボタンをトグルして動的にオン/オフを切り替えることも可能です。

---
*PR created automatically by Jules for task [6451043118713349310](https://jules.google.com/task/6451043118713349310) started by @edgeless*