### PR TITLE
feat: auto-scroll the score when playing long songs

### DIFF
--- a/src/lib/components/ScoreSection.svelte
+++ b/src/lib/components/ScoreSection.svelte
@@ -33,8 +33,12 @@
   }
 
   // 単一の出力先コンテナ
+  let scoreArea: HTMLDivElement | undefined = $state();
   let scoreContainer: HTMLDivElement | undefined = $state();
   let containerWidth = $state(600);
+
+  // Auto-scroll tracking
+  let activeRowIdx = $state(-1);
 
   /** 行のレイアウト情報を一括計算する */
   function getRowLayout(W: number, row: number) {
@@ -146,10 +150,31 @@
   let animationFrameId: number = 0;
   let cursorStyle = $state({ display: 'none', left: '0px', top: '0px', height: '0px' });
 
+  // Auto-scroll logic when activeRowIdx changes
+  $effect(() => {
+    if ((playerState.isPlaying || playerState.isRecording) && activeRowIdx >= 0 && scoreArea && scoreContainer) {
+      const rowEl = scoreContainer.querySelector(`#score-row-${activeRowIdx}`) as HTMLElement;
+      if (rowEl) {
+        // Calculate the row's top relative to the container
+        const rowTop = rowEl.offsetTop;
+        // Use auto for the first scroll, smooth for subsequent ones
+        const behavior = scoreArea.scrollTop === 0 && activeRowIdx === 0 ? 'auto' : 'smooth';
+
+        scoreArea.scrollTo({
+          top: rowTop,
+          behavior
+        });
+      }
+    }
+  });
+
   $effect(() => {
     void rowLayouts;
     void viewMode;
     if (playerState.isPlaying || playerState.isRecording) {
+      // Reset active row when playback starts from the beginning or loops
+      activeRowIdx = -1;
+
       function updateCursor() {
         if (!scoreContainer) return;
 
@@ -177,6 +202,10 @@
         }
 
         if (targetRowIdx !== -1) {
+          if (targetRowIdx !== activeRowIdx) {
+            activeRowIdx = targetRowIdx;
+          }
+
           const layout = rowLayouts[targetRowIdx];
           const rowEl = scoreContainer.querySelector(`#score-row-${targetRowIdx}`) as HTMLElement;
 
@@ -254,6 +283,7 @@
       // Not playing, ensure cursor matches current static position if possible, or hide it
       if (animationFrameId) cancelAnimationFrame(animationFrameId);
       cursorStyle.display = 'none';
+      activeRowIdx = -1;
     }
   });
 
@@ -351,7 +381,7 @@
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div class="stab {viewMode === 'tab' ? 'active' : ''}" onclick={() => viewMode = 'tab'}>タブ譜</div>
   </div>
-  <div class="score-area">
+  <div bind:this={scoreArea} class="score-area">
     <div bind:this={scoreContainer} bind:clientWidth={containerWidth} class="score-container">
       {#each rowLayouts as layout, row}
         <div id="score-row-{row}" style="position:relative;">

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -43,3 +43,68 @@ test('transport components are correctly rendered and accessible', async ({ page
   // ensure the volume control is present
   await expect(page.locator(".vol-ctrl[title='音量']")).toBeVisible();
 });
+
+test('auto-scrolls the score section during playback of long songs', async ({ page }) => {
+  // Use fake UI for media stream to automatically bypass mic permission prompts at the browser level
+  await page.goto('/');
+
+  // Dismiss overlay if present
+  const dismissBtn = page.locator("button:has-text('マイク')");
+  if (await dismissBtn.isVisible()) {
+    await dismissBtn.click({ force: true });
+  }
+
+  // Wait for React/Svelte hydration
+  await page.waitForLoadState('networkidle');
+
+  // Inject a mock song and directly fast-forward the player state to simulate playback crossing a row boundary.
+  // This avoids flaky time-based audio playback in headless CI environments while still testing the auto-scroll Svelte effect logic.
+  await page.evaluate(() => {
+    // Inject a long song
+    const song = {
+        name: "Test Long Song",
+        bpm: 120, 
+        timeSignature: [4, 4],
+        notes: [
+            {"name":"C3", "midi":36, "string":"A", "fret":3, "beat":0, "dur":1},
+            {"name":"C3", "midi":36, "string":"A", "fret":3, "beat":10, "dur":1},
+            {"name":"C3", "midi":36, "string":"A", "fret":3, "beat":20, "dur":1},
+            {"name":"C3", "midi":36, "string":"A", "fret":3, "beat":30, "dur":1},
+        ]
+    };
+    const ps = (window as any).__states.playerState;
+    ps.song = song;
+    ps.currentSongKey = "test-long-song";
+  });
+  
+  // Wait for score to render multiple rows
+  await expect(page.locator('#score-row-0')).toBeVisible();
+  await expect(page.locator('#score-row-1')).toBeVisible();
+
+  const scoreArea = page.locator('.score-area').first();
+  
+  // Initial scroll top should be 0
+  const initialScrollTop = await scoreArea.evaluate((el) => el.scrollTop);
+  expect(initialScrollTop).toBe(0);
+
+  // Directly mock the player state to think it's playing and it's at beat 18 (which is on row 1)
+  await page.evaluate(() => {
+    const ps = (window as any).__states.playerState;
+    ps.status = 'playing';
+    ps.isPlaying = true;
+    
+    // We mock the playback time directly
+    // Since count-in is 4 beats (ps.song.timeSignature[0] = 4), beat 18 is 22 beats into playback
+    // 22 beats at 120 bpm (2 beats per sec) = 11 seconds = 11000ms
+    ps.playbackStartTimeMs = performance.now() - 11000;
+  });
+
+  // Because the updateCursor loop runs via requestAnimationFrame, it should pick up the new time,
+  // calculate the new targetRowIdx (1), and trigger the Svelte effect to scroll.
+  await expect(async () => {
+    const scrollTop = await scoreArea.evaluate((el) => el.scrollTop);
+    expect(scrollTop).toBeGreaterThan(0);
+  }).toPass({
+    timeout: 5000, 
+  });
+});


### PR DESCRIPTION
Implemented auto-scrolling to keep the actively playing row at the top of the visible score area, improving the user experience for long songs. Tested via automated e2e tests and visually verified using Playwright.

---
*PR created automatically by Jules for task [10218659715307300116](https://jules.google.com/task/10218659715307300116) started by @edgeless*