### PR TITLE
🧪 [testing improvement] Add tests for getCountInBeats

### DIFF
--- a/tests/unit/player.test.ts
+++ b/tests/unit/player.test.ts
@@ -5,7 +5,8 @@ import {
   getDisplayBeat,
   getOriginalBeats,
   getTotalBeats,
-  getTotalDurationSeconds
+  getTotalDurationSeconds,
+  getCountInBeats
 } from '../../src/lib/stores/player.svelte';
 
 describe('getDisplayBeat', () => {
@@ -87,6 +88,36 @@ describe('getDisplayBeat', () => {
 
     const displayBeat = getDisplayBeat();
     assert.strictEqual(displayBeat, 5);
+  });
+});
+
+describe('getCountInBeats', () => {
+  beforeEach(() => {
+    playerState.song = {
+      name: 'Test',
+      bpm: 60,
+      notes: []
+    };
+  });
+
+  test('returns 4 when timeSignature is undefined', () => {
+    playerState.song.timeSignature = undefined;
+    assert.strictEqual(getCountInBeats(), 4);
+  });
+
+  test('returns the numerator of a standard time signature (e.g. 3 for [3, 4])', () => {
+    playerState.song.timeSignature = [3, 4];
+    assert.strictEqual(getCountInBeats(), 3);
+  });
+
+  test('returns the numerator of a different time signature (e.g. 6 for [6, 8])', () => {
+    playerState.song.timeSignature = [6, 8];
+    assert.strictEqual(getCountInBeats(), 6);
+  });
+
+  test('returns 4 when timeSignature is an empty array', () => {
+    playerState.song.timeSignature = [] as unknown as [number, number];
+    assert.strictEqual(getCountInBeats(), 4);
   });
 });
 


### PR DESCRIPTION
🎯 **What:** The testing gap for `getCountInBeats` in `src/lib/stores/player.svelte.ts` was addressed. Previously, this helper function lacked test coverage.
📊 **Coverage:** The following scenarios are now tested:
- Default behavior when no time signature is present (returns 4).
- Normal behavior with standard time signatures like `[3, 4]` (returns 3) or `[6, 8]` (returns 6).
- Edge case handling when the time signature is an empty array (falls back to 4).
✨ **Result:** The test suite accurately verifies that the count-in calculation correctly interprets the song's time signature properties or gracefully falls back. This increases test coverage and ensures future modifications won't break rhythm timing.

---
*PR created automatically by Jules for task [2135722447850878074](https://jules.google.com/task/2135722447850878074) started by @edgeless*