### PR TITLE
🔒 [security fix] Complete HTML Escaping Function

### DIFF
--- a/src/lib/utils/security.ts
+++ b/src/lib/utils/security.ts
@@ -5,13 +5,15 @@
  */
 export function escapeHtml(input: any): string {
   const str = String(input);
-  return str.replace(/[&<>"']/g, (m) => {
+  return str.replace(/[&<>"'`\/]/g, (m) => {
     return {
       '&': '&amp;',
       '<': '&lt;',
       '>': '&gt;',
       '"': '&quot;',
       "'": '&#39;',
+      '/': '&#x2F;',
+      '`': '&#x60;',
     }[m] as string;
   });
 }

--- a/tests/unit/security.test.ts
+++ b/tests/unit/security.test.ts
@@ -19,8 +19,19 @@ describe('escapeHtml', () => {
     assert.strictEqual(escapeHtml("'test'"), '&#39;test&#39;');
   });
 
+  test('escapes /', () => {
+    assert.strictEqual(escapeHtml('</a>'), '&lt;&#x2F;a&gt;');
+  });
+
+  test('escapes `', () => {
+    assert.strictEqual(escapeHtml('`test`'), '&#x60;test&#x60;');
+  });
+
   test('escapes multiple characters', () => {
-    assert.strictEqual(escapeHtml('<a href="x&y">test\'s</a>'), '&lt;a href=&quot;x&amp;y&quot;&gt;test&#39;s&lt;/a&gt;');
+    assert.strictEqual(
+      escapeHtml('<a href="x&y">test\'s / `</a>'),
+      '&lt;a href=&quot;x&amp;y&quot;&gt;test&#39;s &#x2F; &#x60;&lt;&#x2F;a&gt;'
+    );
   });
 
   test('coerces non-strings to string', () => {


### PR DESCRIPTION
🎯 **What:** The `escapeHtml` function was missing escaping for forward slash (`/`) and backtick (`` ` ``).
⚠️ **Risk:** Incomplete escaping can allow XSS attacks in certain HTML contexts or older browsers where these characters have special meaning.
🛡️ **Solution:** Updated the regular expression and replacement map in `escapeHtml` to include `/` (as `&#x2F;`) and `` ` `` (as `&#x60;`). Added unit tests to verify the fix.

---
*PR created automatically by Jules for task [3613782250259763622](https://jules.google.com/task/3613782250259763622) started by @edgeless*