### PR TITLE
🧹 Remove console.log for Timing Note

### DIFF
--- a/src/lib/components/Transport.svelte
+++ b/src/lib/components/Transport.svelte
@@ -441,7 +441,6 @@
         const yinLatencyMs = 3000 / firstFreq;
         timingDiffMs = (firstSampleTime - audioState.latencyCompensationMs - yinLatencyMs) - expectedNoteTimeMs;
         timingGrade = getTimingGrade(Math.abs(timingDiffMs));
-        console.log(`[Timing] Note ${rs.noteIdx}: diff=${Math.round(timingDiffMs)}ms, grade=${timingGrade}`);
       }
 
       const combinedGrade = getCombinedGrade(pitchGrade, timingGrade);


### PR DESCRIPTION
Removed a debug console.log statement in Transport.svelte that was outputting timing information for each note during post-analysis. This improves code health by removing unnecessary noise from the console in production-like environments.

---
*PR created automatically by Jules for task [14169195733275395074](https://jules.google.com/task/14169195733275395074) started by @edgeless*