### PR TITLE
🧪 Add tests for keyToDroneFreq in pitch utilities

### DIFF
--- a/src/lib/utils/pitch.ts
+++ b/src/lib/utils/pitch.ts
@@ -106,7 +106,6 @@ export function keyToDroneFreq(key: string | undefined): number | null {
   if (!match) return null;
   const rootNote = match[0];
 
-  // C1 (MIDI 24) をベースとする（ドローン音は低めに設定）
   const noteOffsets: Record<string, number> = {
     'C': 0, 'C#': 1, 'Db': 1,
     'D': 2, 'D#': 3, 'Eb': 3,

--- a/tests/unit/pitch.test.ts
+++ b/tests/unit/pitch.test.ts
@@ -8,7 +8,8 @@ import {
   getGrade,
   getTimingGrade,
   getCombinedGrade,
-  detectPitch
+  detectPitch,
+  keyToDroneFreq
 } from '../../src/lib/utils/pitch';
 
 describe('pitch utils', () => {
@@ -114,5 +115,44 @@ describe('pitch utils', () => {
 
     const detected = detectPitch(mockAnalyser, pitchBuf, sr);
     assert.strictEqual(detected, -1);
+  });
+
+  describe('keyToDroneFreq', () => {
+    test('returns null for undefined or empty key', () => {
+      assert.strictEqual(keyToDroneFreq(undefined), null);
+      assert.strictEqual(keyToDroneFreq(''), null);
+    });
+
+    test('returns null for invalid key strings', () => {
+      assert.strictEqual(keyToDroneFreq('H'), null);
+      assert.strictEqual(keyToDroneFreq('123'), null);
+      assert.strictEqual(keyToDroneFreq('Xyz'), null);
+    });
+
+    test('converts basic keys to correct drone frequencies (MIDI 36 base)', () => {
+      // C -> MIDI 36
+      assert.strictEqual(keyToDroneFreq('C'), midiToFreq(36));
+      // C# -> MIDI 37
+      assert.strictEqual(keyToDroneFreq('C#'), midiToFreq(37));
+      // Db -> MIDI 37
+      assert.strictEqual(keyToDroneFreq('Db'), midiToFreq(37));
+      // G -> MIDI 43 (36 + 7)
+      assert.strictEqual(keyToDroneFreq('G'), midiToFreq(43));
+      // A -> MIDI 45 (36 + 9)
+      assert.strictEqual(keyToDroneFreq('A'), midiToFreq(45));
+      // B -> MIDI 47 (36 + 11)
+      assert.strictEqual(keyToDroneFreq('B'), midiToFreq(47));
+    });
+
+    test('handles keys with suffixes', () => {
+      // Am -> A (MIDI 45)
+      assert.strictEqual(keyToDroneFreq('Am'), midiToFreq(45));
+      // Cmaj7 -> C (MIDI 36)
+      assert.strictEqual(keyToDroneFreq('Cmaj7'), midiToFreq(36));
+      // F#m7b5 -> F# (MIDI 42, 36 + 6)
+      assert.strictEqual(keyToDroneFreq('F#m7b5'), midiToFreq(42));
+      // Eb7 -> Eb (MIDI 39, 36 + 3)
+      assert.strictEqual(keyToDroneFreq('Eb7'), midiToFreq(39));
+    });
   });
 });


### PR DESCRIPTION
This PR adds unit tests for the `keyToDroneFreq` utility function in `src/lib/utils/pitch.ts`. The tests verify that the function correctly extracts the root note from key strings (including those with suffixes like "maj7" or "m") and maps them to the appropriate drone frequency based on MIDI 36 (C2).

Key changes:
- Updated `tests/unit/pitch.test.ts` to include a new `describe` block for `keyToDroneFreq`.
- Removed a stale comment in `src/lib/utils/pitch.ts` that incorrectly referenced MIDI 24 as the base, whereas the code actually uses MIDI 36 for better mobile speaker audibility.

---
*PR created automatically by Jules for task [6227203557959864550](https://jules.google.com/task/6227203557959864550) started by @edgeless*