### PR TITLE
🧪 [testing improvement] Add JSON.parse error recovery tests for score history

### DIFF
--- a/tests/unit/score.test.ts
+++ b/tests/unit/score.test.ts
@@ -1,6 +1,6 @@
-import { describe, it } from 'node:test';
+import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
-import { scoreState, resetScore, calculateScorePercentages, type NoteResult } from '../../src/lib/stores/score.svelte';
+import { scoreState, resetScore, calculateScorePercentages, saveScoreHistory, loadScoreHistory, type NoteResult } from '../../src/lib/stores/score.svelte';
 
 describe('resetScore', () => {
   it('resets scoreState to default values', () => {
@@ -40,5 +40,87 @@ describe('calculateScorePercentages', () => {
     assert.strictEqual(percentages.pitchPercent, 0);
     assert.strictEqual(percentages.timingPercent, 0);
     assert.strictEqual(percentages.overallPercent, 0);
+  });
+});
+
+describe('score history persistence', () => {
+  let originalLocalStorage: any;
+  let store: Record<string, string>;
+
+  beforeEach(() => {
+    store = {};
+    const mockLocalStorage = {
+      getItem: (key: string) => store[key] || null,
+      setItem: (key: string, value: string) => {
+        store[key] = value.toString();
+      },
+      clear: () => {
+        store = {};
+      }
+    };
+    originalLocalStorage = (global as any).localStorage;
+    (global as any).localStorage = mockLocalStorage;
+  });
+
+  afterEach(() => {
+    if (originalLocalStorage) {
+      (global as any).localStorage = originalLocalStorage;
+    } else {
+      delete (global as any).localStorage;
+    }
+  });
+
+  describe('saveScoreHistory', () => {
+    it('handles invalid JSON in existing history gracefully', () => {
+      const songKey = 'test-song';
+      // Setup invalid JSON
+      (global as any).localStorage.setItem(`score_history_${songKey}`, '{invalid-json');
+
+      const newScore = {
+        overallPercent: 95,
+        pitchPercent: 90,
+        timingPercent: 100
+      };
+
+      // Suppress console.error for this test
+      const originalConsoleError = console.error;
+      console.error = () => {};
+
+      try {
+        saveScoreHistory(songKey, newScore);
+      } finally {
+        console.error = originalConsoleError;
+      }
+
+      // Read back to verify it recovered and saved the new score
+      const savedData = JSON.parse((global as any).localStorage.getItem(`score_history_${songKey}`));
+      assert.strictEqual(Array.isArray(savedData), true);
+      assert.strictEqual(savedData.length, 1);
+      assert.strictEqual(savedData[0].overallPercent, 95);
+      assert.strictEqual(savedData[0].pitchPercent, 90);
+      assert.strictEqual(savedData[0].timingPercent, 100);
+      assert.ok(savedData[0].timestamp > 0);
+    });
+  });
+
+  describe('loadScoreHistory', () => {
+    it('handles invalid JSON gracefully and returns an empty array', () => {
+      const songKey = 'test-song-2';
+      // Setup invalid JSON
+      (global as any).localStorage.setItem(`score_history_${songKey}`, '[not, valid json]');
+
+      // Suppress console.error for this test
+      const originalConsoleError = console.error;
+      console.error = () => {};
+
+      let result;
+      try {
+        result = loadScoreHistory(songKey);
+      } finally {
+        console.error = originalConsoleError;
+      }
+
+      assert.deepStrictEqual(result, []);
+    });
   });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the lack of coverage for the `JSON.parse` error recovery path inside the score history persistence methods (`saveScoreHistory` and `loadScoreHistory`) within `score.svelte.ts`.
📊 **Coverage:** The new tests now explicitly set corrupted JSON data in a mocked `localStorage`, call both methods, and verify that they handle the parsing error gracefully—initializing a fresh array for new saves and returning an empty array on load.
✨ **Result:** Enhanced test coverage, protecting the app from crashing when encountering malformed `localStorage` data for historical scores.

---
*PR created automatically by Jules for task [8135012676776877566](https://jules.google.com/task/8135012676776877566) started by @edgeless*