### PR TITLE
🧹 Remove unnecessary console.log debug statements

### DIFF
--- a/src/lib/stores/audio.svelte.ts
+++ b/src/lib/stores/audio.svelte.ts
@@ -61,7 +61,6 @@ if (typeof window !== 'undefined' && (window.AudioContext || (window as any).web
   try {
     const AC = window.AudioContext || (window as any).webkitAudioContext;
     audioState.audioCtx = new AC();
-    console.log("[Audio] Sample rate:", audioState.audioCtx.sampleRate);
     audioState.analyserNode = audioState.audioCtx.createAnalyser();
     audioState.analyserNode.fftSize = 4096;
     audioState.analyserNode.smoothingTimeConstant = 0.1;
@@ -122,7 +121,6 @@ export async function requestMic(deviceIdOrEvent?: string | Event) {
     
     function initNodes() {
       if (!audioState.audioCtx) return;
-      console.log("[Audio] initNodes called");
       audioState.analyserNode = audioState.audioCtx.createAnalyser();
       audioState.analyserNode.fftSize = 4096;
       audioState.analyserNode.smoothingTimeConstant = 0.1;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -10,10 +10,10 @@
       registerSW({
         immediate: true,
         onRegistered(r: ServiceWorkerRegistration | undefined) {
-          console.log('SW Registered:', r);
+          // SW registered successfully
         },
         onRegisterError(error: Error) {
-          console.log('SW registration error', error);
+          console.error('SW registration error', error);
         }
       });
     }


### PR DESCRIPTION
🎯 **What:** Removed non-essential `console.log` debug statements from `src/lib/stores/audio.svelte.ts` and `src/routes/+layout.svelte`. Changed error reporting log in Service Worker setup to use `console.error`.
💡 **Why:** Debug logs pollute the standard output in production/normal use and should generally be removed for better code health and cleaner diagnostic logs. Converting actual error logging to `console.error` ensures better categorization of problems.
✅ **Verification:** Ran `bun test` for unit tests and `svelte-check` to ensure there are no build/syntax regressions. Manually verified via code review that no actual logic was changed.
✨ **Result:** A cleaner codebase with reduced console noise during normal operation.

---
*PR created automatically by Jules for task [16465813403966035898](https://jules.google.com/task/16465813403966035898) started by @edgeless*